### PR TITLE
Add sample usage to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-[anthropic-ai-sdk/README.md](anthropic-ai-sdk/README.md)
+# Anthropic SDK for Rust
+
+## Sample Usage
+
+Here's a simple example of how to use the Anthropic SDK:
+
+```rust
+use anthropic_sdk::Client;
+
+async fn example() {
+    let client = Client::new("your_api_key");
+    let response = client.complete("Hello, how are you?").await;
+    println!("{}", response);
+}
+```
+
+Feel free to explore more features of the SDK in the documentation.


### PR DESCRIPTION
Adds a sample usage section to the README.md file as requested in issue #15.

Changes:
- Added a sample Rust code demonstrating how to use the Anthropic SDK
- Provides a basic example of client initialization and completion