### PR TITLE
Add support for thinking requests

### DIFF
--- a/anthropic-ai-sdk/src/types/message.rs
+++ b/anthropic-ai-sdk/src/types/message.rs
@@ -206,6 +206,12 @@ pub enum ContentBlock {
         tool_use_id: String,
         content: String,
     },
+    /// Thinking content
+    #[serde(rename = "thinking")]
+    Thinking { thinking: String, signature: String },
+    /// Redacted thinking
+    #[serde(rename = "redacted_thinking")]
+    RedactedThinking { data: String },
 }
 
 /// Source of an image

--- a/anthropic-ai-sdk/src/types/message.rs
+++ b/anthropic-ai-sdk/src/types/message.rs
@@ -78,6 +78,9 @@ pub struct CreateMessageParams {
     /// How the model should use tools
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
+    /// Configuration for enabling Claude's extended thinking.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<Thinking>,
     /// Request metadata
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
@@ -138,6 +141,11 @@ impl CreateMessageParams {
 
     pub fn with_tool_choice(mut self, tool_choice: ToolChoice) -> Self {
         self.tool_choice = Some(tool_choice);
+        self
+    }
+
+    pub fn with_thinking(mut self, thinking: Thinking) -> Self {
+        self.thinking = Some(thinking);
         self
     }
 
@@ -239,6 +247,20 @@ pub enum ToolChoice {
     Tool { name: String },
 }
 
+/// Configuration for extended thinking
+#[derive(Debug, Serialize)]
+pub struct Thinking {
+    /// Must be at least 1024 tokens
+    pub budget_tokens: usize,
+    #[serde(rename = "type")]
+    pub type_: ThinkingType,
+}
+
+#[derive(Debug, Serialize)]
+pub enum ThinkingType {
+    #[serde(rename = "enabled")]
+    Enabled
+}
 /// Message metadata
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Metadata {

--- a/examples/messages/stream-messages/src/main.rs
+++ b/examples/messages/stream-messages/src/main.rs
@@ -1,7 +1,5 @@
 use anthropic_ai_sdk::client::AnthropicClient;
-use anthropic_ai_sdk::types::message::{
-    CreateMessageParams, Message, MessageClient, MessageError, RequiredMessageParams, Role,
-};
+use anthropic_ai_sdk::types::message::{CreateMessageParams, Message, MessageClient, MessageError, RequiredMessageParams, Role, Thinking, ThinkingType};
 use futures_util::StreamExt;
 use std::env;
 use tracing::{error, info};
@@ -24,11 +22,15 @@ async fn main() {
     let client = AnthropicClient::new::<MessageError>(api_key, api_version).unwrap();
 
     let body = CreateMessageParams::new(RequiredMessageParams {
-        model: "claude-3-5-sonnet-20240620".to_string(),
+        model: "claude-3-7-sonnet-latest".to_string(),
         messages: vec![Message::new_text(Role::User, "Hello, Claude")],
-        max_tokens: 1024,
+        max_tokens: 2048,
     })
-    .with_stream(true);
+    .with_stream(true)
+    .with_thinking(Thinking {
+        budget_tokens: 1024,
+        type_: ThinkingType::Enabled
+    });
 
     match client.create_message_streaming(&body).await {
         Ok(mut stream) => {


### PR DESCRIPTION
I added support for "thinking" requests to the library following the general library patterns and the anthropic docs.

https://docs.anthropic.com/en/api/messages

I updated the streaming example to use a thinking model and tested it e2e.