### PR TITLE
Fix streaming base URL handling

### DIFF
--- a/anthropic-ai-sdk/src/messages.rs
+++ b/anthropic-ai-sdk/src/messages.rs
@@ -133,7 +133,7 @@ impl MessageClient for AnthropicClient {
             ));
         }
 
-        let url = format!("{}/messages", AnthropicClient::DEFAULT_API_BASE_URL);
+        let url = format!("{}/messages", self.get_api_base_url());
 
         let client = &self.get_client();
         let request = client


### PR DESCRIPTION
## Summary
- use `self.get_api_base_url()` when streaming messages so custom API base URLs work

## Testing
- `cargo test` *(fails: failed to download dependencies)*