### PR TITLE
Clamp limit in ListModelsParams and add tests

### DIFF
--- a/anthropic-ai-sdk/src/types/model.rs
+++ b/anthropic-ai-sdk/src/types/model.rs
@@ -104,7 +104,24 @@ impl ListModelsParams {
 
     /// Set the limit parameter
     pub fn limit(mut self, limit: u16) -> Self {
-        self.limit = Some(limit.min(1000));
+        self.limit = Some(limit.clamp(1, 1000));
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ListModelsParams;
+
+    #[test]
+    fn limit_clamps_to_upper_bound() {
+        let params = ListModelsParams::new().limit(1500);
+        assert_eq!(params.limit, Some(1000));
+    }
+
+    #[test]
+    fn limit_clamps_to_lower_bound() {
+        let params = ListModelsParams::new().limit(0);
+        assert_eq!(params.limit, Some(1));
     }
 }


### PR DESCRIPTION
## Summary
- clamp ListModelsParams limit via limit.clamp(1, 1000)
- add tests verifying the clamping behavior

## Testing
- `cargo fmt --all -- --check` *(fails: 'cargo-fmt' is not installed)*
- `cargo test -p anthropic-ai-sdk` *(fails to fetch dependencies: Could not connect to server)*