### PR TITLE
Add admin get user endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "examples/admin/api-keys/list-api-keys",
     "examples/admin/api-keys/get-api-key",
     "examples/admin/api-keys/update-api-key",
-    ]
+    "examples/admin/organization-member-management/get-user",
+]
 default-members = ["anthropic-ai-sdk"]
 resolver = "2"

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -109,7 +109,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
   - [x] Delete a Message Batch
 - Admin API
   - Organization Member Management
-    - [ ] Get User
+    - [x] Get User
     - [ ] List Users
     - [ ] Update User
     - [ ] Remove User

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -8,6 +8,7 @@ use crate::types::admin::api_keys::{
     AdminClient, AdminError, AdminUpdateApiKeyParams, ApiKey, ListApiKeysParams,
     ListApiKeysResponse,
 };
+use crate::types::admin::users::OrganizationUser;
 use async_trait::async_trait;
 
 #[async_trait]
@@ -170,5 +171,11 @@ impl AdminClient for AnthropicClient {
             Some(params),
         )
         .await
+    }
+
+    /// Retrieves a user in the organization
+    async fn get_user<'a>(&'a self, user_id: &'a str) -> Result<OrganizationUser, AdminError> {
+        self.get(&format!("/organizations/users/{}", user_id), Option::<&()>::None)
+            .await
     }
 }

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -41,6 +41,8 @@ pub trait AdminClient {
         api_key_id: &'a str,
         params: &'a AdminUpdateApiKeyParams,
     ) -> Result<ApiKey, AdminError>;
+
+    async fn get_user<'a>(&'a self, user_id: &'a str) -> Result<crate::types::admin::users::OrganizationUser, AdminError>;
 }
 
 /// Parameters for listing API keys

--- a/anthropic-ai-sdk/src/types/admin/mod.rs
+++ b/anthropic-ai-sdk/src/types/admin/mod.rs
@@ -1,1 +1,2 @@
 pub mod api_keys;
+pub mod users;

--- a/anthropic-ai-sdk/src/types/admin/users.rs
+++ b/anthropic-ai-sdk/src/types/admin/users.rs
@@ -1,0 +1,32 @@
+use serde::Deserialize;
+use time::serde::rfc3339;
+use time::OffsetDateTime;
+
+/// Organization role of the user.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UserRole {
+    User,
+    Developer,
+    Billing,
+    Admin,
+}
+
+/// Detailed information about an organization user.
+#[derive(Debug, Deserialize)]
+pub struct OrganizationUser {
+    /// When the user was added to the organization.
+    #[serde(with = "rfc3339")]
+    pub added_at: OffsetDateTime,
+    /// Email of the user.
+    pub email: String,
+    /// ID of the user.
+    pub id: String,
+    /// Name of the user.
+    pub name: String,
+    /// Role of the user within the organization.
+    pub role: UserRole,
+    /// Object type. Always `"user"`.
+    #[serde(rename = "type")]
+    pub type_: String,
+}

--- a/examples/admin/organization-member-management/get-user/Cargo.toml
+++ b/examples/admin/organization-member-management/get-user/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "get-user"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/organization-member-management/get-user/src/main.rs
+++ b/examples/admin/organization-member-management/get-user/src/main.rs
@@ -1,0 +1,38 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    // Get the user ID from command line arguments
+    let args: Vec<String> = env::args().collect();
+    let user_id = args
+        .get(1)
+        .expect("Please provide a user ID as argument");
+
+    let user = AdminClient::get_user(&client, user_id).await?;
+
+    println!("User Details:");
+    println!("  ID: {}", user.id);
+    println!("  Name: {}", user.name);
+    println!("  Email: {}", user.email);
+    println!("  Role: {:?}", user.role);
+    println!("  Added At: {}", user.added_at);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement Admin API `get_user`
- expose `OrganizationUser` data type
- show `get-user` example
- document new endpoint in README
- include new example in workspace

## Testing
- `cargo check` *(fails: failed to download crates)*