### PR TITLE
Add Admin list users API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "examples/admin/api-keys/get-api-key",
     "examples/admin/api-keys/update-api-key",
     "examples/admin/organization-member-management/get-user",
+    "examples/admin/organization-member-management/list-users",
 ]
 default-members = ["anthropic-ai-sdk"]
 resolver = "2"

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -110,7 +110,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
 - Admin API
   - Organization Member Management
     - [x] Get User
-    - [ ] List Users
+    - [x] List Users
     - [ ] Update User
     - [ ] Remove User
   - Organization Invites

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -8,7 +8,9 @@ use crate::types::admin::api_keys::{
     AdminClient, AdminError, AdminUpdateApiKeyParams, ApiKey, ListApiKeysParams,
     ListApiKeysResponse,
 };
-use crate::types::admin::users::OrganizationUser;
+use crate::types::admin::users::{
+    ListUsersParams, ListUsersResponse, OrganizationUser,
+};
 use async_trait::async_trait;
 
 #[async_trait]
@@ -171,6 +173,14 @@ impl AdminClient for AnthropicClient {
             Some(params),
         )
         .await
+    }
+
+    /// Lists organization users
+    async fn list_users<'a>(
+        &'a self,
+        params: Option<&'a ListUsersParams>,
+    ) -> Result<ListUsersResponse, AdminError> {
+        self.get("/organizations/users", params).await
     }
 
     /// Retrieves a user in the organization

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -4,6 +4,7 @@
 //!
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use super::users::{ListUsersParams, ListUsersResponse};
 use thiserror::Error;
 use time::OffsetDateTime;
 use time::serde::rfc3339;
@@ -41,6 +42,11 @@ pub trait AdminClient {
         api_key_id: &'a str,
         params: &'a AdminUpdateApiKeyParams,
     ) -> Result<ApiKey, AdminError>;
+
+    async fn list_users<'a>(
+        &'a self,
+        params: Option<&'a ListUsersParams>,
+    ) -> Result<ListUsersResponse, AdminError>;
 
     async fn get_user<'a>(&'a self, user_id: &'a str) -> Result<crate::types::admin::users::OrganizationUser, AdminError>;
 }

--- a/anthropic-ai-sdk/src/types/admin/users.rs
+++ b/anthropic-ai-sdk/src/types/admin/users.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use time::serde::rfc3339;
 use time::OffsetDateTime;
 
@@ -29,4 +29,82 @@ pub struct OrganizationUser {
     /// Object type. Always `"user"`.
     #[serde(rename = "type")]
     pub type_: String,
+}
+
+/// Parameters for listing organization users
+#[derive(Debug, Serialize, Default)]
+pub struct ListUsersParams {
+    /// Cursor for pagination (before)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_id: Option<String>,
+    /// Cursor for pagination (after)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_id: Option<String>,
+    /// Number of items per page (1-1000)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u16>,
+    /// Filter by user email
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
+
+impl ListUsersParams {
+    /// Create a new `ListUsersParams` with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the `before_id` parameter
+    pub fn before_id(mut self, before_id: impl Into<String>) -> Self {
+        self.before_id = Some(before_id.into());
+        self
+    }
+
+    /// Set the `after_id` parameter
+    pub fn after_id(mut self, after_id: impl Into<String>) -> Self {
+        self.after_id = Some(after_id.into());
+        self
+    }
+
+    /// Set the `limit` parameter (1-1000)
+    pub fn limit(mut self, limit: u16) -> Self {
+        self.limit = Some(limit.clamp(1, 1000));
+        self
+    }
+
+    /// Set the `email` filter
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+}
+
+/// Response structure for listing organization users
+#[derive(Debug, Deserialize)]
+pub struct ListUsersResponse {
+    /// List of users
+    pub data: Vec<OrganizationUser>,
+    /// First ID in the data list
+    pub first_id: Option<String>,
+    /// Indicates if there are more results
+    pub has_more: bool,
+    /// Last ID in the data list
+    pub last_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ListUsersParams;
+
+    #[test]
+    fn limit_clamps_upper_bound() {
+        let params = ListUsersParams::new().limit(2000);
+        assert_eq!(params.limit, Some(1000));
+    }
+
+    #[test]
+    fn limit_clamps_lower_bound() {
+        let params = ListUsersParams::new().limit(0);
+        assert_eq!(params.limit, Some(1));
+    }
 }

--- a/examples/admin/organization-member-management/list-users/Cargo.toml
+++ b/examples/admin/organization-member-management/list-users/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "list-users"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/organization-member-management/list-users/src/main.rs
+++ b/examples/admin/organization-member-management/list-users/src/main.rs
@@ -1,0 +1,39 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::users::ListUsersParams;
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let params = ListUsersParams::new().limit(20);
+
+    match AdminClient::list_users(&client, Some(&params)).await {
+        Ok(users) => {
+            info!("Successfully listed organization users:");
+            for user in users.data {
+                info!("- {} ({})", user.email, user.id);
+            }
+        }
+        Err(e) => {
+            error!("Error listing users: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support listing organization users via Admin API
- implement AdminClient::list_users
- example for listing users
- document new capability

## Testing
- `cargo fmt` *(fails: component not installed)*
- `cargo test --workspace --all-targets` *(fails: could not connect to crates.io)*