### PR TITLE
Add workspace admin endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-workspace"
+version = "0.1.0"
+dependencies = [
+ "anthropic-ai-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +762,16 @@ dependencies = [
 
 [[package]]
 name = "list-users"
+version = "0.1.0"
+dependencies = [
+ "anthropic-ai-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "list-workspaces"
 version = "0.1.0"
 dependencies = [
  "anthropic-ai-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ members = [
     "examples/admin/api-keys/update-api-key",
     "examples/admin/organization-member-management/get-user",
     "examples/admin/organization-member-management/list-users",
+    "examples/admin/workspace-management/get-workspace",
+    "examples/admin/workspace-management/list-workspaces",
 ]
 default-members = ["anthropic-ai-sdk"]
 resolver = "2"

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -119,8 +119,8 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
     - [ ] Create Invite
     - [ ] Delete Invite
   - Workspace Management
-    - [ ] Get Workspace
-    - [ ] List Workspaces
+    - [x] Get Workspace
+    - [x] List Workspaces
     - [ ] Update Workspace
     - [ ] Create Workspace
     - [ ] Archive Workspace

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -11,6 +11,9 @@ use crate::types::admin::api_keys::{
 use crate::types::admin::users::{
     ListUsersParams, ListUsersResponse, OrganizationUser,
 };
+use crate::types::admin::workspaces::{
+    GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse,
+};
 use async_trait::async_trait;
 
 #[async_trait]
@@ -187,5 +190,23 @@ impl AdminClient for AnthropicClient {
     async fn get_user<'a>(&'a self, user_id: &'a str) -> Result<OrganizationUser, AdminError> {
         self.get(&format!("/organizations/users/{}", user_id), Option::<&()>::None)
             .await
+    }
+
+    async fn list_workspaces<'a>(
+        &'a self,
+        params: Option<&'a ListWorkspacesParams>,
+    ) -> Result<ListWorkspacesResponse, AdminError> {
+        self.get("/organizations/workspaces", params).await
+    }
+
+    async fn get_workspace<'a>(
+        &'a self,
+        workspace_id: &'a str,
+    ) -> Result<GetWorkspaceResponse, AdminError> {
+        self.get(
+            &format!("/organizations/workspaces/{}", workspace_id),
+            Option::<&()>::None,
+        )
+        .await
     }
 }

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use super::users::{ListUsersParams, ListUsersResponse};
 use super::workspaces::{
-    GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse, Workspace,
+    GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse,
 };
 use thiserror::Error;
 use time::OffsetDateTime;

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -5,6 +5,9 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use super::users::{ListUsersParams, ListUsersResponse};
+use super::workspaces::{
+    GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse, Workspace,
+};
 use thiserror::Error;
 use time::OffsetDateTime;
 use time::serde::rfc3339;
@@ -49,6 +52,13 @@ pub trait AdminClient {
     ) -> Result<ListUsersResponse, AdminError>;
 
     async fn get_user<'a>(&'a self, user_id: &'a str) -> Result<crate::types::admin::users::OrganizationUser, AdminError>;
+
+    async fn list_workspaces<'a>(
+        &'a self,
+        params: Option<&'a ListWorkspacesParams>,
+    ) -> Result<ListWorkspacesResponse, AdminError>;
+
+    async fn get_workspace<'a>(&'a self, workspace_id: &'a str) -> Result<GetWorkspaceResponse, AdminError>;
 }
 
 /// Parameters for listing API keys

--- a/anthropic-ai-sdk/src/types/admin/mod.rs
+++ b/anthropic-ai-sdk/src/types/admin/mod.rs
@@ -1,2 +1,3 @@
 pub mod api_keys;
 pub mod users;
+pub mod workspaces;

--- a/anthropic-ai-sdk/src/types/admin/workspaces.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspaces.rs
@@ -1,0 +1,105 @@
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use time::serde::rfc3339;
+
+/// Workspace information returned by the Admin API.
+#[derive(Debug, Deserialize)]
+pub struct Workspace {
+    /// When the workspace was archived, if at all.
+    #[serde(with = "rfc3339::option")]
+    pub archived_at: Option<OffsetDateTime>,
+    /// When the workspace was created.
+    #[serde(with = "rfc3339")]
+    pub created_at: OffsetDateTime,
+    /// Hex color code representing the workspace.
+    pub display_color: String,
+    /// ID of the workspace.
+    pub id: String,
+    /// Name of the workspace.
+    pub name: String,
+    /// Object type (always "workspace").
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+/// Parameters for listing workspaces.
+#[derive(Debug, Serialize, Default)]
+pub struct ListWorkspacesParams {
+    /// Whether to include archived workspaces in the response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_archived: Option<bool>,
+    /// Cursor for pagination (before).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_id: Option<String>,
+    /// Cursor for pagination (after).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_id: Option<String>,
+    /// Number of items per page (1-1000).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u16>,
+}
+
+impl ListWorkspacesParams {
+    /// Create a new `ListWorkspacesParams` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Include archived workspaces in the response.
+    pub fn include_archived(mut self, include: bool) -> Self {
+        self.include_archived = Some(include);
+        self
+    }
+
+    /// Set the `before_id` parameter.
+    pub fn before_id(mut self, before_id: impl Into<String>) -> Self {
+        self.before_id = Some(before_id.into());
+        self
+    }
+
+    /// Set the `after_id` parameter.
+    pub fn after_id(mut self, after_id: impl Into<String>) -> Self {
+        self.after_id = Some(after_id.into());
+        self
+    }
+
+    /// Set the `limit` parameter (1-1000).
+    pub fn limit(mut self, limit: u16) -> Self {
+        self.limit = Some(limit.clamp(1, 1000));
+        self
+    }
+}
+
+/// Response structure for listing workspaces.
+#[derive(Debug, Deserialize)]
+pub struct ListWorkspacesResponse {
+    /// List of workspaces returned.
+    pub data: Vec<Workspace>,
+    /// First ID in the list.
+    pub first_id: Option<String>,
+    /// Indicates if there are more results.
+    pub has_more: bool,
+    /// Last ID in the list.
+    pub last_id: Option<String>,
+}
+
+/// Response type for retrieving a workspace.
+pub type GetWorkspaceResponse = Workspace;
+
+#[cfg(test)]
+mod tests {
+    use super::ListWorkspacesParams;
+
+    #[test]
+    fn limit_clamps_upper_bound() {
+        let params = ListWorkspacesParams::new().limit(2000);
+        assert_eq!(params.limit, Some(1000));
+    }
+
+    #[test]
+    fn limit_clamps_lower_bound() {
+        let params = ListWorkspacesParams::new().limit(0);
+        assert_eq!(params.limit, Some(1));
+    }
+}
+

--- a/examples/admin/workspace-management/get-workspace/Cargo.toml
+++ b/examples/admin/workspace-management/get-workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "get-workspace"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-management/get-workspace/src/main.rs
+++ b/examples/admin/workspace-management/get-workspace/src/main.rs
@@ -1,0 +1,26 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args
+        .get(1)
+        .expect("Please provide a workspace ID as argument");
+
+    let workspace = AdminClient::get_workspace(&client, workspace_id).await?;
+    println!("Workspace: {} ({})", workspace.name, workspace.id);
+    println!("Display Color: {}", workspace.display_color);
+    println!("Created At: {}", workspace.created_at);
+    if let Some(archived_at) = workspace.archived_at {
+        println!("Archived At: {}", archived_at);
+    }
+
+    Ok(())
+}

--- a/examples/admin/workspace-management/list-workspaces/Cargo.toml
+++ b/examples/admin/workspace-management/list-workspaces/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "list-workspaces"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-management/list-workspaces/src/main.rs
+++ b/examples/admin/workspace-management/list-workspaces/src/main.rs
@@ -1,0 +1,39 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::workspaces::ListWorkspacesParams;
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let params = ListWorkspacesParams::new().limit(20);
+
+    match AdminClient::list_workspaces(&client, Some(&params)).await {
+        Ok(resp) => {
+            info!("Workspaces:");
+            for ws in resp.data {
+                info!("- {} ({})", ws.name, ws.id);
+            }
+        }
+        Err(e) => {
+            error!("Error listing workspaces: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support Admin API workspace management
- implement get_workspace and list_workspaces
- expose types for workspaces
- add examples for the new endpoints

## Testing
- `cargo test` *(fails: failed to download crates due to network)*