### PR TITLE
Add workspace member management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "anthropic-ai-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-trait",
  "eventsource-stream",
@@ -367,6 +367,16 @@ dependencies = [
 
 [[package]]
 name = "get-workspace"
+version = "0.1.0"
+dependencies = [
+ "anthropic-ai-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "get-workspace-member"
 version = "0.1.0"
 dependencies = [
  "anthropic-ai-sdk",
@@ -762,6 +772,16 @@ dependencies = [
 
 [[package]]
 name = "list-users"
+version = "0.1.0"
+dependencies = [
+ "anthropic-ai-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "list-workspace-members"
 version = "0.1.0"
 dependencies = [
  "anthropic-ai-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ members = [
     "examples/admin/organization-member-management/list-users",
     "examples/admin/workspace-management/get-workspace",
     "examples/admin/workspace-management/list-workspaces",
+    "examples/admin/workspace-member-management/get-workspace-member",
+    "examples/admin/workspace-member-management/list-workspace-members",
 ]
 default-members = ["anthropic-ai-sdk"]
 resolver = "2"

--- a/anthropic-ai-sdk/Cargo.toml
+++ b/anthropic-ai-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anthropic-ai-sdk"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 authors = ["Katsuhiro Honda<freewave3@gmail.com>"]
 categories = ["api-bindings"]

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -15,6 +15,7 @@ use crate::types::admin::workspaces::{
     GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse,
 };
 use async_trait::async_trait;
+use crate::types::admin::workspace_members::{GetWorkspaceMemberResponse, ListWorkspaceMembersParams, ListWorkspaceMembersResponse};
 
 #[async_trait]
 impl AdminClient for AnthropicClient {
@@ -205,6 +206,30 @@ impl AdminClient for AnthropicClient {
     ) -> Result<GetWorkspaceResponse, AdminError> {
         self.get(
             &format!("/organizations/workspaces/{}", workspace_id),
+            Option::<&()>::None,
+        )
+        .await
+    }
+
+    async fn list_workspace_members<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        params: Option<&'a ListWorkspaceMembersParams>,
+    ) -> Result<ListWorkspaceMembersResponse, AdminError> {
+        self.get(
+            &format!("/organizations/workspaces/{}/members", workspace_id),
+            params,
+        )
+        .await
+    }
+
+    async fn get_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        user_id: &'a str,
+    ) -> Result<GetWorkspaceMemberResponse, AdminError> {
+        self.get(
+            &format!("/organizations/workspaces/{}/members/{}", workspace_id, user_id),
             Option::<&()>::None,
         )
         .await

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -9,6 +9,7 @@ use super::workspaces::{
     GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse,
 };
 use thiserror::Error;
+use super::workspace_members::{GetWorkspaceMemberResponse, ListWorkspaceMembersParams, ListWorkspaceMembersResponse};
 use time::OffsetDateTime;
 use time::serde::rfc3339;
 
@@ -59,6 +60,18 @@ pub trait AdminClient {
     ) -> Result<ListWorkspacesResponse, AdminError>;
 
     async fn get_workspace<'a>(&'a self, workspace_id: &'a str) -> Result<GetWorkspaceResponse, AdminError>;
+
+    async fn list_workspace_members<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        params: Option<&'a ListWorkspaceMembersParams>,
+    ) -> Result<ListWorkspaceMembersResponse, AdminError>;
+
+    async fn get_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        user_id: &'a str,
+    ) -> Result<GetWorkspaceMemberResponse, AdminError>;
 }
 
 /// Parameters for listing API keys

--- a/anthropic-ai-sdk/src/types/admin/mod.rs
+++ b/anthropic-ai-sdk/src/types/admin/mod.rs
@@ -1,3 +1,4 @@
 pub mod api_keys;
 pub mod users;
 pub mod workspaces;
+pub mod workspace_members;

--- a/anthropic-ai-sdk/src/types/admin/workspace_members.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspace_members.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+/// Role of the Workspace Member.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceRole {
+    WorkspaceUser,
+    WorkspaceDeveloper,
+    WorkspaceAdmin,
+    WorkspaceBilling,
+}
+
+/// Information about a workspace member returned by the Admin API.
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceMember {
+    /// Object type. Always `"workspace_member"`.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// ID of the user.
+    pub user_id: String,
+    /// ID of the workspace.
+    pub workspace_id: String,
+    /// Role of the member within the workspace.
+    pub workspace_role: WorkspaceRole,
+}
+
+/// Parameters for listing workspace members.
+#[derive(Debug, Serialize, Default)]
+pub struct ListWorkspaceMembersParams {
+    /// Cursor for pagination (before).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_id: Option<String>,
+    /// Cursor for pagination (after).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_id: Option<String>,
+    /// Number of items per page (1-1000).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u16>,
+}
+
+impl ListWorkspaceMembersParams {
+    /// Create a new `ListWorkspaceMembersParams` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the `before_id` parameter.
+    pub fn before_id(mut self, before_id: impl Into<String>) -> Self {
+        self.before_id = Some(before_id.into());
+        self
+    }
+
+    /// Set the `after_id` parameter.
+    pub fn after_id(mut self, after_id: impl Into<String>) -> Self {
+        self.after_id = Some(after_id.into());
+        self
+    }
+
+    /// Set the `limit` parameter (1-1000).
+    pub fn limit(mut self, limit: u16) -> Self {
+        self.limit = Some(limit.clamp(1, 1000));
+        self
+    }
+}
+
+/// Response structure for listing workspace members.
+#[derive(Debug, Deserialize)]
+pub struct ListWorkspaceMembersResponse {
+    /// List of workspace members returned.
+    pub data: Vec<WorkspaceMember>,
+    /// First ID in the data list.
+    pub first_id: Option<String>,
+    /// Indicates if there are more results.
+    pub has_more: bool,
+    /// Last ID in the data list.
+    pub last_id: Option<String>,
+}
+
+/// Response type for retrieving a workspace member.
+pub type GetWorkspaceMemberResponse = WorkspaceMember;
+
+#[cfg(test)]
+mod tests {
+    use super::ListWorkspaceMembersParams;
+
+    #[test]
+    fn limit_clamps_upper_bound() {
+        let params = ListWorkspaceMembersParams::new().limit(2000);
+        assert_eq!(params.limit, Some(1000));
+    }
+
+    #[test]
+    fn limit_clamps_lower_bound() {
+        let params = ListWorkspaceMembersParams::new().limit(0);
+        assert_eq!(params.limit, Some(1));
+    }
+}

--- a/examples/admin/workspace-member-management/get-workspace-member/Cargo.toml
+++ b/examples/admin/workspace-member-management/get-workspace-member/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "get-workspace-member"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-member-management/get-workspace-member/src/main.rs
+++ b/examples/admin/workspace-member-management/get-workspace-member/src/main.rs
@@ -1,0 +1,39 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+use tracing::{info, error};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args.get(1).expect("Provide workspace ID as first argument");
+    let user_id = args.get(2).expect("Provide user ID as second argument");
+
+    match AdminClient::get_workspace_member(&client, workspace_id, user_id).await {
+        Ok(member) => {
+            info!("Workspace Member: {:?}", member.workspace_role);
+            info!("User ID: {}", member.user_id);
+            info!("Workspace ID: {}", member.workspace_id);
+        }
+        Err(e) => {
+            error!("Error getting workspace member: {}", e);
+        }
+    }
+
+    Ok(())
+}

--- a/examples/admin/workspace-member-management/list-workspace-members/Cargo.toml
+++ b/examples/admin/workspace-member-management/list-workspace-members/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "list-workspace-members"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-member-management/list-workspace-members/src/main.rs
+++ b/examples/admin/workspace-member-management/list-workspace-members/src/main.rs
@@ -1,0 +1,41 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::workspace_members::ListWorkspaceMembersParams;
+use std::env;
+use tracing::{info, error};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args.get(1).expect("Provide workspace ID as argument");
+
+    let params = ListWorkspaceMembersParams::new().limit(20);
+
+    match AdminClient::list_workspace_members(&client, workspace_id, Some(&params)).await {
+        Ok(resp) => {
+            for member in resp.data {
+                info!("{} -> {:?}", member.user_id, member.workspace_role);
+            }
+        }
+        Err(e) => {
+            error!("Error listing members: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support listing/getting workspace members in the admin API client
- define workspace member types
- add workspace member management examples
- include new examples in workspace

## Testing
- `cargo test` *(fails: could not download crates)*