### PR TITLE
Implement organization invite retrieval APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "anthropic-ai-sdk"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-trait",
  "eventsource-stream",
@@ -347,6 +347,16 @@ dependencies = [
 
 [[package]]
 name = "get-api-key"
+version = "0.1.0"
+dependencies = [
+ "anthropic-ai-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "get-invite"
 version = "0.1.0"
 dependencies = [
  "anthropic-ai-sdk",
@@ -742,6 +752,16 @@ checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "list-api-keys"
+version = "0.1.0"
+dependencies = [
+ "anthropic-ai-sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "list-invites"
 version = "0.1.0"
 dependencies = [
  "anthropic-ai-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ members = [
     "examples/admin/workspace-management/list-workspaces",
     "examples/admin/workspace-member-management/get-workspace-member",
     "examples/admin/workspace-member-management/list-workspace-members",
+    "examples/admin/organization-invites/get-invite",
+    "examples/admin/organization-invites/list-invites",
 ]
 default-members = ["anthropic-ai-sdk"]
 resolver = "2"

--- a/anthropic-ai-sdk/Cargo.toml
+++ b/anthropic-ai-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anthropic-ai-sdk"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 authors = ["Katsuhiro Honda<freewave3@gmail.com>"]
 categories = ["api-bindings"]

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -89,6 +89,9 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
   - [Count Message Tokens](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/messages/count-message-tokens/src/main.rs) - How to count tokens in a message
 - Message Batch
   - [Create a Message Batch](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/message-batches/create-a-message-batch/src/main.rs) - How to create a message batch
+- Admin Invites
+  - [Get Invite](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/get-invite/src/main.rs) - How to retrieve an organization invite
+  - [List Invites](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/list-invites/src/main.rs) - How to list organization invites
 
 > **Note:** The examples listed above are only a subset. For additional detailed usage examples, please refer to the [examples directory](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/examples).
 
@@ -114,8 +117,8 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
     - [ ] Update User
     - [ ] Remove User
   - Organization Invites
-    - [ ] Get Invite
-    - [ ] List Invites
+    - [x] Get Invite
+    - [x] List Invites
     - [ ] Create Invite
     - [ ] Delete Invite
   - Workspace Management

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -16,6 +16,7 @@ use crate::types::admin::workspaces::{
 };
 use async_trait::async_trait;
 use crate::types::admin::workspace_members::{GetWorkspaceMemberResponse, ListWorkspaceMembersParams, ListWorkspaceMembersResponse};
+use crate::types::admin::invites::{GetInviteResponse, ListInvitesParams, ListInvitesResponse};
 
 #[async_trait]
 impl AdminClient for AnthropicClient {
@@ -233,5 +234,16 @@ impl AdminClient for AnthropicClient {
             Option::<&()>::None,
         )
         .await
+    }
+
+    async fn list_invites<'a>(
+        &'a self,
+        params: Option<&'a ListInvitesParams>,
+    ) -> Result<ListInvitesResponse, AdminError> {
+        self.get("/organizations/invites", params).await
+    }
+
+    async fn get_invite<'a>(&'a self, invite_id: &'a str) -> Result<GetInviteResponse, AdminError> {
+        self.get(&format!("/organizations/invites/{}", invite_id), Option::<&()>::None).await
     }
 }

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -10,6 +10,7 @@ use super::workspaces::{
 };
 use thiserror::Error;
 use super::workspace_members::{GetWorkspaceMemberResponse, ListWorkspaceMembersParams, ListWorkspaceMembersResponse};
+use super::invites::{GetInviteResponse, ListInvitesParams, ListInvitesResponse};
 use time::OffsetDateTime;
 use time::serde::rfc3339;
 
@@ -72,6 +73,13 @@ pub trait AdminClient {
         workspace_id: &'a str,
         user_id: &'a str,
     ) -> Result<GetWorkspaceMemberResponse, AdminError>;
+
+    async fn list_invites<'a>(
+        &'a self,
+        params: Option<&'a ListInvitesParams>,
+    ) -> Result<ListInvitesResponse, AdminError>;
+
+    async fn get_invite<'a>(&'a self, invite_id: &'a str) -> Result<GetInviteResponse, AdminError>;
 }
 
 /// Parameters for listing API keys

--- a/anthropic-ai-sdk/src/types/admin/invites.rs
+++ b/anthropic-ai-sdk/src/types/admin/invites.rs
@@ -1,0 +1,110 @@
+use serde::{Deserialize, Serialize};
+use time::serde::rfc3339;
+use time::OffsetDateTime;
+
+use super::users::UserRole;
+
+/// Status of the Invite.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InviteStatus {
+    Accepted,
+    Expired,
+    Deleted,
+    Pending,
+}
+
+/// Information about an organization invite.
+#[derive(Debug, Deserialize)]
+pub struct Invite {
+    /// Email of the User being invited.
+    pub email: String,
+    /// RFC 3339 datetime string indicating when the Invite expires.
+    #[serde(with = "rfc3339")]
+    pub expires_at: OffsetDateTime,
+    /// ID of the Invite.
+    pub id: String,
+    /// RFC 3339 datetime string indicating when the Invite was created.
+    #[serde(with = "rfc3339")]
+    pub invited_at: OffsetDateTime,
+    /// Organization role of the User.
+    pub role: UserRole,
+    /// Status of the Invite.
+    pub status: InviteStatus,
+    /// Object type. Always `"invite"`.
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+/// Parameters for listing invites.
+#[derive(Debug, Serialize, Default)]
+pub struct ListInvitesParams {
+    /// Cursor for pagination (before).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_id: Option<String>,
+    /// Cursor for pagination (after).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_id: Option<String>,
+    /// Number of items per page (1-1000).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u16>,
+}
+
+impl ListInvitesParams {
+    /// Create a new `ListInvitesParams` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the `before_id` parameter.
+    pub fn before_id(mut self, before_id: impl Into<String>) -> Self {
+        self.before_id = Some(before_id.into());
+        self
+    }
+
+    /// Set the `after_id` parameter.
+    pub fn after_id(mut self, after_id: impl Into<String>) -> Self {
+        self.after_id = Some(after_id.into());
+        self
+    }
+
+    /// Set the `limit` parameter (1-1000).
+    pub fn limit(mut self, limit: u16) -> Self {
+        self.limit = Some(limit.clamp(1, 1000));
+        self
+    }
+}
+
+/// Response structure for listing invites.
+#[derive(Debug, Deserialize)]
+pub struct ListInvitesResponse {
+    /// List of invites returned.
+    pub data: Vec<Invite>,
+    /// First ID in the data list. Can be used as the before_id for the previous page.
+    pub first_id: Option<String>,
+    /// Indicates if there are more results in the requested page direction.
+    pub has_more: bool,
+    /// Last ID in the data list. Can be used as the after_id for the next page.
+    pub last_id: Option<String>,
+}
+
+/// Response type for retrieving an invite.
+pub type GetInviteResponse = Invite;
+
+#[cfg(test)]
+mod tests {
+    use super::ListInvitesParams;
+
+    #[test]
+    fn limit_clamps_upper_bound() {
+        let params = ListInvitesParams::new().limit(2000);
+        assert_eq!(params.limit, Some(1000));
+    }
+
+    #[test]
+    fn limit_clamps_lower_bound() {
+        let params = ListInvitesParams::new().limit(0);
+        assert_eq!(params.limit, Some(1));
+    }
+}
+

--- a/anthropic-ai-sdk/src/types/admin/mod.rs
+++ b/anthropic-ai-sdk/src/types/admin/mod.rs
@@ -2,3 +2,4 @@ pub mod api_keys;
 pub mod users;
 pub mod workspaces;
 pub mod workspace_members;
+pub mod invites;

--- a/examples/admin/organization-invites/get-invite/Cargo.toml
+++ b/examples/admin/organization-invites/get-invite/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "get-invite"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"

--- a/examples/admin/organization-invites/get-invite/src/main.rs
+++ b/examples/admin/organization-invites/get-invite/src/main.rs
@@ -1,0 +1,38 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let invite_id = args
+        .get(1)
+        .expect("Please provide an invite ID as argument");
+
+    let invite = AdminClient::get_invite(&client, invite_id).await?;
+
+    println!("Invite Details:");
+    println!("  ID: {}", invite.id);
+    println!("  Email: {}", invite.email);
+    println!("  Role: {:?}", invite.role);
+    println!("  Status: {:?}", invite.status);
+    println!("  Invited At: {}", invite.invited_at);
+    println!("  Expires At: {}", invite.expires_at);
+
+    Ok(())
+}

--- a/examples/admin/organization-invites/list-invites/Cargo.toml
+++ b/examples/admin/organization-invites/list-invites/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "list-invites"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"

--- a/examples/admin/organization-invites/list-invites/src/main.rs
+++ b/examples/admin/organization-invites/list-invites/src/main.rs
@@ -1,0 +1,38 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::invites::ListInvitesParams;
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let params = ListInvitesParams::new().limit(20);
+
+    match AdminClient::list_invites(&client, Some(&params)).await {
+        Ok(resp) => {
+            for invite in resp.data {
+                info!("{} -> {} {:?}", invite.id, invite.email, invite.status);
+            }
+        }
+        Err(e) => {
+            error!("Error listing invites: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support Admin API organization invites
- add new AdminClient methods
- track progress in README
- add examples for getting and listing invites

## Testing
- `cargo fmt --all` *(fails: 'cargo-fmt' not installed)*
- `cargo test --workspace --quiet` *(fails: could not download crates)*