### PR TITLE
Implement Admin Update User

### DIFF
--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -114,7 +114,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
   - Organization Member Management
     - [x] Get User
     - [x] List Users
-    - [ ] Update User
+    - [x] Update User
     - [ ] Remove User
   - Organization Invites
     - [x] Get Invite

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -9,7 +9,7 @@ use crate::types::admin::api_keys::{
     ListApiKeysResponse,
 };
 use crate::types::admin::users::{
-    ListUsersParams, ListUsersResponse, OrganizationUser,
+    AdminUpdateUserParams, ListUsersParams, ListUsersResponse, OrganizationUser,
 };
 use crate::types::admin::workspaces::{
     GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse,
@@ -192,6 +192,18 @@ impl AdminClient for AnthropicClient {
     async fn get_user<'a>(&'a self, user_id: &'a str) -> Result<OrganizationUser, AdminError> {
         self.get(&format!("/organizations/users/{}", user_id), Option::<&()>::None)
             .await
+    }
+
+    async fn update_user<'a>(
+        &'a self,
+        user_id: &'a str,
+        params: &'a AdminUpdateUserParams,
+    ) -> Result<OrganizationUser, AdminError> {
+        self.post(
+            &format!("/organizations/users/{}", user_id),
+            Some(params),
+        )
+        .await
     }
 
     async fn list_workspaces<'a>(

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -55,6 +55,12 @@ pub trait AdminClient {
 
     async fn get_user<'a>(&'a self, user_id: &'a str) -> Result<crate::types::admin::users::OrganizationUser, AdminError>;
 
+    async fn update_user<'a>(
+        &'a self,
+        user_id: &'a str,
+        params: &'a crate::types::admin::users::AdminUpdateUserParams,
+    ) -> Result<crate::types::admin::users::OrganizationUser, AdminError>;
+
     async fn list_workspaces<'a>(
         &'a self,
         params: Option<&'a ListWorkspacesParams>,

--- a/anthropic-ai-sdk/src/types/admin/users.rs
+++ b/anthropic-ai-sdk/src/types/admin/users.rs
@@ -92,6 +92,20 @@ pub struct ListUsersResponse {
     pub last_id: Option<String>,
 }
 
+/// Parameters for updating a user.
+#[derive(Debug, Serialize)]
+pub struct AdminUpdateUserParams {
+    /// New role for the User.
+    pub role: UserRole,
+}
+
+impl AdminUpdateUserParams {
+    /// Create a new `AdminUpdateUserParams` with the required role.
+    pub fn new(role: UserRole) -> Self {
+        Self { role }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ListUsersParams;

--- a/examples/admin/organization-member-management/update-user/Cargo.toml
+++ b/examples/admin/organization-member-management/update-user/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "update-user"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/organization-member-management/update-user/src/main.rs
+++ b/examples/admin/organization-member-management/update-user/src/main.rs
@@ -1,0 +1,51 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::users::{AdminUpdateUserParams, UserRole};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    // Get user_id and role from command line arguments
+    let args: Vec<String> = env::args().collect();
+    let user_id = args.get(1).expect("Please provide a user ID as argument");
+    let role_arg = args.get(2).expect("Please provide a role: user, developer, or billing");
+
+    let role = match role_arg.as_str() {
+        "user" => UserRole::User,
+        "developer" => UserRole::Developer,
+        "billing" => UserRole::Billing,
+        _ => {
+            error!("Invalid role. Valid options: user, developer, billing");
+            return Ok(());
+        }
+    };
+
+    let params = AdminUpdateUserParams::new(role);
+
+    match AdminClient::update_user(&client, user_id, &params).await {
+        Ok(user) => {
+            info!("Successfully updated user: {} -> {:?}", user.email, user.role);
+        }
+        Err(e) => {
+            error!("Error updating user: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement `AdminUpdateUserParams` and support for update_user in admin client
- add example demonstrating how to update a user
- mark Update User as implemented in README

## Testing
- `cargo test` *(fails: failed to download crates)*