### PR TITLE
Add delete user endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "examples/admin/api-keys/update-api-key",
     "examples/admin/organization-member-management/get-user",
     "examples/admin/organization-member-management/list-users",
+    "examples/admin/organization-member-management/remove-user",
     "examples/admin/workspace-management/get-workspace",
     "examples/admin/workspace-management/list-workspaces",
     "examples/admin/workspace-member-management/get-workspace-member",

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -9,7 +9,7 @@ use crate::types::admin::api_keys::{
     ListApiKeysResponse,
 };
 use crate::types::admin::users::{
-    AdminUpdateUserParams, ListUsersParams, ListUsersResponse, OrganizationUser,
+    AdminUpdateUserParams, DeleteUserResponse, ListUsersParams, ListUsersResponse, OrganizationUser,
 };
 use crate::types::admin::workspaces::{
     GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse,
@@ -202,6 +202,14 @@ impl AdminClient for AnthropicClient {
         self.post(
             &format!("/organizations/users/{}", user_id),
             Some(params),
+        )
+        .await
+    }
+
+    async fn delete_user<'a>(&'a self, user_id: &'a str) -> Result<DeleteUserResponse, AdminError> {
+        self.delete::<DeleteUserResponse, (), AdminError>(
+            &format!("/organizations/users/{}", user_id),
+            Option::<&()>::None,
         )
         .await
     }

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -61,6 +61,11 @@ pub trait AdminClient {
         params: &'a crate::types::admin::users::AdminUpdateUserParams,
     ) -> Result<crate::types::admin::users::OrganizationUser, AdminError>;
 
+    async fn delete_user<'a>(
+        &'a self,
+        user_id: &'a str,
+    ) -> Result<crate::types::admin::users::DeleteUserResponse, AdminError>;
+
     async fn list_workspaces<'a>(
         &'a self,
         params: Option<&'a ListWorkspacesParams>,

--- a/anthropic-ai-sdk/src/types/admin/users.rs
+++ b/anthropic-ai-sdk/src/types/admin/users.rs
@@ -106,6 +106,16 @@ impl AdminUpdateUserParams {
     }
 }
 
+/// Response type for deleting a user.
+#[derive(Debug, Deserialize)]
+pub struct DeleteUserResponse {
+    /// ID of the User.
+    pub id: String,
+    /// Deleted object type. Always `"user_deleted"`.
+    #[serde(rename = "type")]
+    pub obj_type: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::ListUsersParams;

--- a/examples/admin/organization-member-management/remove-user/Cargo.toml
+++ b/examples/admin/organization-member-management/remove-user/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "remove-user"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/organization-member-management/remove-user/src/main.rs
+++ b/examples/admin/organization-member-management/remove-user/src/main.rs
@@ -1,0 +1,36 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let user_id = args.get(1).expect("Please provide a user ID as argument");
+
+    match AdminClient::delete_user(&client, user_id).await {
+        Ok(resp) => {
+            info!("Deleted user: {} - {}", resp.obj_type, resp.id);
+        }
+        Err(e) => {
+            error!("Error deleting user: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement delete user in admin client and trait
- add DeleteUserResponse type
- provide example for deleting organization users
- register new example in workspace

## Testing
- `cargo fmt` *(fails: rustfmt component missing)*
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: clippy component missing)*
- `cargo check --workspace` *(fails: could not download crates)*
- `cargo test --workspace` *(fails: could not download crates)*