### PR TITLE
Implement Add Workspace Member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "examples/admin/workspace-management/list-workspaces",
     "examples/admin/workspace-member-management/get-workspace-member",
     "examples/admin/workspace-member-management/list-workspace-members",
+    "examples/admin/workspace-member-management/add-workspace-member",
     "examples/admin/organization-invites/get-invite",
     "examples/admin/organization-invites/list-invites",
 ]

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -130,6 +130,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
   - Workspace Member Management
     - [x] Get Workspace Member
     - [x] List Workspace Members
+    - [x] Add Workspace Member
     - [ ] Update Workspace Member
     - [ ] Delete Workspace Member
   - API Keys

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -15,7 +15,10 @@ use crate::types::admin::workspaces::{
     GetWorkspaceResponse, ListWorkspacesParams, ListWorkspacesResponse,
 };
 use async_trait::async_trait;
-use crate::types::admin::workspace_members::{GetWorkspaceMemberResponse, ListWorkspaceMembersParams, ListWorkspaceMembersResponse};
+use crate::types::admin::workspace_members::{
+    AdminAddWorkspaceMemberParams, GetWorkspaceMemberResponse, ListWorkspaceMembersParams,
+    ListWorkspaceMembersResponse, WorkspaceMember,
+};
 use crate::types::admin::invites::{GetInviteResponse, ListInvitesParams, ListInvitesResponse};
 
 #[async_trait]
@@ -252,6 +255,18 @@ impl AdminClient for AnthropicClient {
         self.get(
             &format!("/organizations/workspaces/{}/members/{}", workspace_id, user_id),
             Option::<&()>::None,
+        )
+        .await
+    }
+
+    async fn add_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        params: &'a AdminAddWorkspaceMemberParams,
+    ) -> Result<WorkspaceMember, AdminError> {
+        self.post(
+            &format!("/organizations/workspaces/{}/members", workspace_id),
+            Some(params),
         )
         .await
     }

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -85,6 +85,12 @@ pub trait AdminClient {
         user_id: &'a str,
     ) -> Result<GetWorkspaceMemberResponse, AdminError>;
 
+    async fn add_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        params: &'a crate::types::admin::workspace_members::AdminAddWorkspaceMemberParams,
+    ) -> Result<crate::types::admin::workspace_members::WorkspaceMember, AdminError>;
+
     async fn list_invites<'a>(
         &'a self,
         params: Option<&'a ListInvitesParams>,

--- a/anthropic-ai-sdk/src/types/admin/workspace_members.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspace_members.rs
@@ -24,6 +24,25 @@ pub struct WorkspaceMember {
     pub workspace_role: WorkspaceRole,
 }
 
+/// Parameters for adding a workspace member.
+#[derive(Debug, Serialize)]
+pub struct AdminAddWorkspaceMemberParams {
+    /// ID of the user to add to the workspace.
+    pub user_id: String,
+    /// Role for the new workspace member.
+    pub workspace_role: WorkspaceRole,
+}
+
+impl AdminAddWorkspaceMemberParams {
+    /// Create new parameters with the required fields.
+    pub fn new(user_id: impl Into<String>, workspace_role: WorkspaceRole) -> Self {
+        Self {
+            user_id: user_id.into(),
+            workspace_role,
+        }
+    }
+}
+
 /// Parameters for listing workspace members.
 #[derive(Debug, Serialize, Default)]
 pub struct ListWorkspaceMembersParams {

--- a/examples/admin/workspace-member-management/add-workspace-member/Cargo.toml
+++ b/examples/admin/workspace-member-management/add-workspace-member/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "add-workspace-member"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-member-management/add-workspace-member/src/main.rs
+++ b/examples/admin/workspace-member-management/add-workspace-member/src/main.rs
@@ -1,0 +1,51 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::workspace_members::{AdminAddWorkspaceMemberParams, WorkspaceRole};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args.get(1).expect("Provide workspace ID as first argument");
+    let user_id = args.get(2).expect("Provide user ID as second argument");
+    let role_arg = args.get(3).expect("Provide workspace role: user, developer, or admin");
+
+    let role = match role_arg.as_str() {
+        "user" => WorkspaceRole::WorkspaceUser,
+        "developer" => WorkspaceRole::WorkspaceDeveloper,
+        "admin" => WorkspaceRole::WorkspaceAdmin,
+        _ => {
+            error!("Invalid role. Valid options: user, developer, admin");
+            return Ok(());
+        }
+    };
+
+    let params = AdminAddWorkspaceMemberParams::new(user_id, role);
+
+    match AdminClient::add_workspace_member(&client, workspace_id, &params).await {
+        Ok(member) => {
+            info!("Added member {} with role {:?}", member.user_id, member.workspace_role);
+        }
+        Err(e) => {
+            error!("Error adding workspace member: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support adding workspace members through AdminClient
- expose `AdminAddWorkspaceMemberParams` for the new endpoint
- provide example `add-workspace-member`
- document coverage in README

## Testing
- `cargo test` *(fails: failed to download crates)*