### PR TITLE
Add create invite admin API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "examples/admin/workspace-member-management/list-workspace-members",
     "examples/admin/organization-invites/get-invite",
     "examples/admin/organization-invites/list-invites",
+    "examples/admin/organization-invites/create-invite",
 ]
 default-members = ["anthropic-ai-sdk"]
 resolver = "2"

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -92,6 +92,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
 - Admin Invites
   - [Get Invite](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/get-invite/src/main.rs) - How to retrieve an organization invite
   - [List Invites](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/list-invites/src/main.rs) - How to list organization invites
+  - [Create Invite](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/create-invite/src/main.rs) - How to create an organization invite
 
 > **Note:** The examples listed above are only a subset. For additional detailed usage examples, please refer to the [examples directory](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/examples).
 
@@ -119,7 +120,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
   - Organization Invites
     - [x] Get Invite
     - [x] List Invites
-    - [ ] Create Invite
+    - [x] Create Invite
     - [ ] Delete Invite
   - Workspace Management
     - [x] Get Workspace

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -263,6 +263,13 @@ impl AdminClient for AnthropicClient {
         self.get("/organizations/invites", params).await
     }
 
+    async fn create_invite<'a>(
+        &'a self,
+        params: &'a crate::types::admin::invites::CreateInviteParams,
+    ) -> Result<crate::types::admin::invites::Invite, AdminError> {
+        self.post("/organizations/invites", Some(params)).await
+    }
+
     async fn get_invite<'a>(&'a self, invite_id: &'a str) -> Result<GetInviteResponse, AdminError> {
         self.get(&format!("/organizations/invites/{}", invite_id), Option::<&()>::None).await
     }

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -90,6 +90,11 @@ pub trait AdminClient {
         params: Option<&'a ListInvitesParams>,
     ) -> Result<ListInvitesResponse, AdminError>;
 
+    async fn create_invite<'a>(
+        &'a self,
+        params: &'a crate::types::admin::invites::CreateInviteParams,
+    ) -> Result<crate::types::admin::invites::Invite, AdminError>;
+
     async fn get_invite<'a>(&'a self, invite_id: &'a str) -> Result<GetInviteResponse, AdminError>;
 }
 

--- a/anthropic-ai-sdk/src/types/admin/invites.rs
+++ b/anthropic-ai-sdk/src/types/admin/invites.rs
@@ -36,6 +36,25 @@ pub struct Invite {
     pub type_: String,
 }
 
+/// Parameters for creating an invite.
+#[derive(Debug, Serialize)]
+pub struct CreateInviteParams {
+    /// Email of the User.
+    pub email: String,
+    /// Role for the invited User. Cannot be `Admin`.
+    pub role: UserRole,
+}
+
+impl CreateInviteParams {
+    /// Create a new [`CreateInviteParams`].
+    pub fn new(email: impl Into<String>, role: UserRole) -> Self {
+        Self {
+            email: email.into(),
+            role,
+        }
+    }
+}
+
 /// Parameters for listing invites.
 #[derive(Debug, Serialize, Default)]
 pub struct ListInvitesParams {

--- a/examples/admin/organization-invites/create-invite/Cargo.toml
+++ b/examples/admin/organization-invites/create-invite/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "create-invite"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"

--- a/examples/admin/organization-invites/create-invite/src/main.rs
+++ b/examples/admin/organization-invites/create-invite/src/main.rs
@@ -1,0 +1,51 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::invites::CreateInviteParams;
+use anthropic_ai_sdk::types::admin::users::UserRole;
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let email = args.get(1).expect("Please provide an email as argument");
+    let role_arg = args.get(2).expect("Please provide a role: user, developer, or billing");
+
+    let role = match role_arg.as_str() {
+        "user" => UserRole::User,
+        "developer" => UserRole::Developer,
+        "billing" => UserRole::Billing,
+        _ => {
+            error!("Invalid role. Valid options: user, developer, billing");
+            return Ok(());
+        }
+    };
+
+    let params = CreateInviteParams::new(email, role);
+
+    match AdminClient::create_invite(&client, &params).await {
+        Ok(invite) => {
+            info!("Successfully created invite: {} -> {}", invite.id, invite.email);
+        }
+        Err(e) => {
+            error!("Error creating invite: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support creating organization invites in Admin API
- expose create invite params and method
- add example for creating invites
- document create invite in README

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo clippy --version` *(fails: component not installed)*
- `cargo check --workspace` *(fails: could not download crates)*
- `cargo build` *(fails: could not download crates)*
- `cargo test` *(fails: could not download crates)*