### PR TITLE
Add workspace update endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "examples/admin/organization-member-management/remove-user",
     "examples/admin/workspace-management/get-workspace",
     "examples/admin/workspace-management/list-workspaces",
+    "examples/admin/workspace-management/update-workspace",
     "examples/admin/workspace-member-management/get-workspace-member",
     "examples/admin/workspace-member-management/list-workspace-members",
     "examples/admin/organization-invites/get-invite",

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -124,7 +124,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
   - Workspace Management
     - [x] Get Workspace
     - [x] List Workspaces
-    - [ ] Update Workspace
+    - [x] Update Workspace
     - [ ] Create Workspace
     - [ ] Archive Workspace
   - Workspace Member Management

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -232,6 +232,18 @@ impl AdminClient for AnthropicClient {
         .await
     }
 
+    async fn update_workspace<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        params: &'a crate::types::admin::workspaces::AdminUpdateWorkspaceParams,
+    ) -> Result<crate::types::admin::workspaces::Workspace, AdminError> {
+        self.post(
+            &format!("/organizations/workspaces/{}", workspace_id),
+            Some(params),
+        )
+        .await
+    }
+
     async fn list_workspace_members<'a>(
         &'a self,
         workspace_id: &'a str,

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -73,6 +73,12 @@ pub trait AdminClient {
 
     async fn get_workspace<'a>(&'a self, workspace_id: &'a str) -> Result<GetWorkspaceResponse, AdminError>;
 
+    async fn update_workspace<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        params: &'a crate::types::admin::workspaces::AdminUpdateWorkspaceParams,
+    ) -> Result<crate::types::admin::workspaces::Workspace, AdminError>;
+
     async fn list_workspace_members<'a>(
         &'a self,
         workspace_id: &'a str,

--- a/anthropic-ai-sdk/src/types/admin/workspaces.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspaces.rs
@@ -86,9 +86,29 @@ pub struct ListWorkspacesResponse {
 /// Response type for retrieving a workspace.
 pub type GetWorkspaceResponse = Workspace;
 
+/// Parameters for updating a workspace.
+#[derive(Debug, Serialize)]
+pub struct AdminUpdateWorkspaceParams {
+    /// Name of the workspace (1-40 characters).
+    pub name: String,
+}
+
+impl AdminUpdateWorkspaceParams {
+    /// Create a new `AdminUpdateWorkspaceParams` with the required name.
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into();
+        assert!(
+            !name.is_empty() && name.chars().count() <= 40,
+            "workspace name must be 1-40 characters"
+        );
+        Self { name }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ListWorkspacesParams;
+    use super::AdminUpdateWorkspaceParams;
 
     #[test]
     fn limit_clamps_upper_bound() {
@@ -100,6 +120,25 @@ mod tests {
     fn limit_clamps_lower_bound() {
         let params = ListWorkspacesParams::new().limit(0);
         assert_eq!(params.limit, Some(1));
+    }
+
+    #[test]
+    fn update_params_accepts_valid_name() {
+        let params = AdminUpdateWorkspaceParams::new("hello");
+        assert_eq!(params.name, "hello");
+    }
+
+    #[test]
+    #[should_panic]
+    fn update_params_rejects_empty_name() {
+        AdminUpdateWorkspaceParams::new("");
+    }
+
+    #[test]
+    #[should_panic]
+    fn update_params_rejects_long_name() {
+        let s = "a".repeat(41);
+        AdminUpdateWorkspaceParams::new(s);
     }
 }
 

--- a/examples/admin/workspace-management/update-workspace/Cargo.toml
+++ b/examples/admin/workspace-management/update-workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "update-workspace"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-management/update-workspace/src/main.rs
+++ b/examples/admin/workspace-management/update-workspace/src/main.rs
@@ -1,0 +1,47 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::workspaces::AdminUpdateWorkspaceParams;
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args.get(1).expect("Please provide a workspace ID as argument");
+    let new_name = args.get(2).expect("Please provide the new workspace name");
+
+    let params = AdminUpdateWorkspaceParams::new(new_name);
+
+    match AdminClient::update_workspace(&client, workspace_id, &params).await {
+        Ok(ws) => {
+            info!("Successfully updated workspace!");
+            info!("  ID: {}", ws.id);
+            info!("  Name: {}", ws.name);
+            info!("  Display Color: {}", ws.display_color);
+            info!("  Created At: {}", ws.created_at);
+            if let Some(archived_at) = ws.archived_at {
+                info!("  Archived At: {}", archived_at);
+            }
+        }
+        Err(e) => {
+            error!("Error updating workspace: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support updating a workspace via admin API
- expose new `AdminUpdateWorkspaceParams`
- implement `update_workspace` in client
- add example for updating a workspace
- validate workspace name length and mark Update Workspace done in README

## Testing
- `cargo build` *(fails: could not download crates)*
- `cargo test` *(fails: could not download crates)*
- `cargo check --workspace` *(fails: could not download crates)*
- `cargo fmt` *(fails: rustfmt not installed)*
