### PR TITLE
Add delete organization invite endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "examples/admin/organization-invites/get-invite",
     "examples/admin/organization-invites/list-invites",
     "examples/admin/organization-invites/create-invite",
+    "examples/admin/organization-invites/delete-invite",
 ]
 default-members = ["anthropic-ai-sdk"]
 resolver = "2"

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -93,6 +93,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
   - [Get Invite](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/get-invite/src/main.rs) - How to retrieve an organization invite
   - [List Invites](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/list-invites/src/main.rs) - How to list organization invites
   - [Create Invite](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/create-invite/src/main.rs) - How to create an organization invite
+  - [Delete Invite](https://github.com/e-bebe/anthropic-sdk-rs/blob/main/examples/admin/organization-invites/delete-invite/src/main.rs) - How to delete an organization invite
 
 > **Note:** The examples listed above are only a subset. For additional detailed usage examples, please refer to the [examples directory](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/examples).
 
@@ -121,7 +122,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
     - [x] Get Invite
     - [x] List Invites
     - [x] Create Invite
-    - [ ] Delete Invite
+    - [x] Delete Invite
   - Workspace Management
     - [x] Get Workspace
     - [x] List Workspaces

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -19,7 +19,9 @@ use crate::types::admin::workspace_members::{
     AdminAddWorkspaceMemberParams, GetWorkspaceMemberResponse, ListWorkspaceMembersParams,
     ListWorkspaceMembersResponse, WorkspaceMember,
 };
-use crate::types::admin::invites::{GetInviteResponse, ListInvitesParams, ListInvitesResponse};
+use crate::types::admin::invites::{
+    DeleteInviteResponse, GetInviteResponse, ListInvitesParams, ListInvitesResponse,
+};
 
 #[async_trait]
 impl AdminClient for AnthropicClient {
@@ -287,5 +289,16 @@ impl AdminClient for AnthropicClient {
 
     async fn get_invite<'a>(&'a self, invite_id: &'a str) -> Result<GetInviteResponse, AdminError> {
         self.get(&format!("/organizations/invites/{}", invite_id), Option::<&()>::None).await
+    }
+
+    async fn delete_invite<'a>(
+        &'a self,
+        invite_id: &'a str,
+    ) -> Result<DeleteInviteResponse, AdminError> {
+        self.delete::<DeleteInviteResponse, (), AdminError>(
+            &format!("/organizations/invites/{}", invite_id),
+            Option::<&()>::None,
+        )
+        .await
     }
 }

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -10,7 +10,9 @@ use super::workspaces::{
 };
 use thiserror::Error;
 use super::workspace_members::{GetWorkspaceMemberResponse, ListWorkspaceMembersParams, ListWorkspaceMembersResponse};
-use super::invites::{GetInviteResponse, ListInvitesParams, ListInvitesResponse};
+use super::invites::{
+    DeleteInviteResponse, GetInviteResponse, ListInvitesParams, ListInvitesResponse,
+};
 use time::OffsetDateTime;
 use time::serde::rfc3339;
 
@@ -102,6 +104,11 @@ pub trait AdminClient {
     ) -> Result<crate::types::admin::invites::Invite, AdminError>;
 
     async fn get_invite<'a>(&'a self, invite_id: &'a str) -> Result<GetInviteResponse, AdminError>;
+
+    async fn delete_invite<'a>(
+        &'a self,
+        invite_id: &'a str,
+    ) -> Result<DeleteInviteResponse, AdminError>;
 }
 
 /// Parameters for listing API keys

--- a/anthropic-ai-sdk/src/types/admin/invites.rs
+++ b/anthropic-ai-sdk/src/types/admin/invites.rs
@@ -110,6 +110,16 @@ pub struct ListInvitesResponse {
 /// Response type for retrieving an invite.
 pub type GetInviteResponse = Invite;
 
+/// Response type for deleting an invite.
+#[derive(Debug, Deserialize)]
+pub struct DeleteInviteResponse {
+    /// ID of the invite.
+    pub id: String,
+    /// Deleted object type. Always `"invite_deleted"`.
+    #[serde(rename = "type")]
+    pub obj_type: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::ListInvitesParams;

--- a/examples/admin/organization-invites/delete-invite/Cargo.toml
+++ b/examples/admin/organization-invites/delete-invite/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "delete-invite"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"

--- a/examples/admin/organization-invites/delete-invite/src/main.rs
+++ b/examples/admin/organization-invites/delete-invite/src/main.rs
@@ -1,0 +1,38 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let invite_id = args
+        .get(1)
+        .expect("Please provide an invite ID as argument");
+
+    match AdminClient::delete_invite(&client, invite_id).await {
+        Ok(resp) => {
+            info!("Deleted invite: {} - {}", resp.obj_type, resp.id);
+        }
+        Err(e) => {
+            error!("Error deleting invite: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support deleting organization invites
- expose delete_invite on the AdminClient trait
- implement delete_invite for AnthropicClient
- add example showing how to delete an invite
- mark delete invite as implemented in README

## Testing
- `cargo fmt` *(failed: component not installed)*
- `cargo clippy` *(failed: component not installed)*
- `cargo build` *(failed: could not download crates)*
- `cargo test` *(failed: could not download crates)*
- `cargo check --workspace` *(failed: could not download crates)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.