### PR TITLE
Add update workspace member endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "examples/admin/workspace-member-management/get-workspace-member",
     "examples/admin/workspace-member-management/list-workspace-members",
     "examples/admin/workspace-member-management/add-workspace-member",
+    "examples/admin/workspace-member-management/update-workspace-member",
     "examples/admin/organization-invites/get-invite",
     "examples/admin/organization-invites/list-invites",
     "examples/admin/organization-invites/create-invite",

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -132,7 +132,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
     - [x] Get Workspace Member
     - [x] List Workspace Members
     - [x] Add Workspace Member
-    - [ ] Update Workspace Member
+    - [x] Update Workspace Member
     - [ ] Delete Workspace Member
   - API Keys
     - [x] Get API Key

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -16,8 +16,9 @@ use crate::types::admin::workspaces::{
 };
 use async_trait::async_trait;
 use crate::types::admin::workspace_members::{
-    AdminAddWorkspaceMemberParams, GetWorkspaceMemberResponse, ListWorkspaceMembersParams,
-    ListWorkspaceMembersResponse, WorkspaceMember,
+    AdminAddWorkspaceMemberParams, AdminUpdateWorkspaceMemberParams,
+    GetWorkspaceMemberResponse, ListWorkspaceMembersParams, ListWorkspaceMembersResponse,
+    WorkspaceMember,
 };
 use crate::types::admin::invites::{GetInviteResponse, ListInvitesParams, ListInvitesResponse};
 
@@ -266,6 +267,22 @@ impl AdminClient for AnthropicClient {
     ) -> Result<WorkspaceMember, AdminError> {
         self.post(
             &format!("/organizations/workspaces/{}/members", workspace_id),
+            Some(params),
+        )
+        .await
+    }
+
+    async fn update_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        user_id: &'a str,
+        params: &'a AdminUpdateWorkspaceMemberParams,
+    ) -> Result<WorkspaceMember, AdminError> {
+        self.post(
+            &format!(
+                "/organizations/workspaces/{}/members/{}",
+                workspace_id, user_id
+            ),
             Some(params),
         )
         .await

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -91,6 +91,13 @@ pub trait AdminClient {
         params: &'a crate::types::admin::workspace_members::AdminAddWorkspaceMemberParams,
     ) -> Result<crate::types::admin::workspace_members::WorkspaceMember, AdminError>;
 
+    async fn update_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        user_id: &'a str,
+        params: &'a crate::types::admin::workspace_members::AdminUpdateWorkspaceMemberParams,
+    ) -> Result<crate::types::admin::workspace_members::WorkspaceMember, AdminError>;
+
     async fn list_invites<'a>(
         &'a self,
         params: Option<&'a ListInvitesParams>,

--- a/anthropic-ai-sdk/src/types/admin/workspace_members.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspace_members.rs
@@ -43,6 +43,20 @@ impl AdminAddWorkspaceMemberParams {
     }
 }
 
+/// Parameters for updating a workspace member.
+#[derive(Debug, Serialize)]
+pub struct AdminUpdateWorkspaceMemberParams {
+    /// New workspace role for the User.
+    pub workspace_role: WorkspaceRole,
+}
+
+impl AdminUpdateWorkspaceMemberParams {
+    /// Create new parameters with the required workspace role.
+    pub fn new(workspace_role: WorkspaceRole) -> Self {
+        Self { workspace_role }
+    }
+}
+
 /// Parameters for listing workspace members.
 #[derive(Debug, Serialize, Default)]
 pub struct ListWorkspaceMembersParams {

--- a/examples/admin/workspace-member-management/update-workspace-member/Cargo.toml
+++ b/examples/admin/workspace-member-management/update-workspace-member/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "update-workspace-member"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-member-management/update-workspace-member/src/main.rs
+++ b/examples/admin/workspace-member-management/update-workspace-member/src/main.rs
@@ -1,0 +1,56 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::workspace_members::{
+    AdminUpdateWorkspaceMemberParams, WorkspaceRole,
+};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args
+        .get(1)
+        .expect("Provide workspace ID as first argument");
+    let user_id = args.get(2).expect("Provide user ID as second argument");
+    let role_arg = args.get(3).expect("Provide workspace role: user, developer, admin or billing");
+
+    let role = match role_arg.as_str() {
+        "user" => WorkspaceRole::WorkspaceUser,
+        "developer" => WorkspaceRole::WorkspaceDeveloper,
+        "admin" => WorkspaceRole::WorkspaceAdmin,
+        "billing" => WorkspaceRole::WorkspaceBilling,
+        _ => {
+            error!("Invalid role. Valid options: user, developer, admin, billing");
+            return Ok(());
+        }
+    };
+
+    let params = AdminUpdateWorkspaceMemberParams::new(role);
+
+    match AdminClient::update_workspace_member(&client, workspace_id, user_id, &params).await {
+        Ok(member) => {
+            info!("Updated member {} -> {:?}", member.user_id, member.workspace_role);
+        }
+        Err(e) => {
+            error!("Error updating workspace member: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support updating workspace member roles
- expose update function in AdminClient
- add example for updating workspace members
- document update workspace member in API coverage table

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo build` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*