### PR TITLE
Implement workspace creation endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "examples/admin/organization-member-management/remove-user",
     "examples/admin/workspace-management/get-workspace",
     "examples/admin/workspace-management/list-workspaces",
+    "examples/admin/workspace-management/create-workspace",
     "examples/admin/workspace-management/update-workspace",
     "examples/admin/workspace-member-management/get-workspace-member",
     "examples/admin/workspace-member-management/list-workspace-members",

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -227,6 +227,13 @@ impl AdminClient for AnthropicClient {
         self.get("/organizations/workspaces", params).await
     }
 
+    async fn create_workspace<'a>(
+        &'a self,
+        params: &'a crate::types::admin::workspaces::AdminCreateWorkspaceParams,
+    ) -> Result<crate::types::admin::workspaces::CreateWorkspaceResponse, AdminError> {
+        self.post("/organizations/workspaces", Some(params)).await
+    }
+
     async fn get_workspace<'a>(
         &'a self,
         workspace_id: &'a str,

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -73,6 +73,11 @@ pub trait AdminClient {
         params: Option<&'a ListWorkspacesParams>,
     ) -> Result<ListWorkspacesResponse, AdminError>;
 
+    async fn create_workspace<'a>(
+        &'a self,
+        params: &'a crate::types::admin::workspaces::AdminCreateWorkspaceParams,
+    ) -> Result<crate::types::admin::workspaces::CreateWorkspaceResponse, AdminError>;
+
     async fn get_workspace<'a>(&'a self, workspace_id: &'a str) -> Result<GetWorkspaceResponse, AdminError>;
 
     async fn update_workspace<'a>(

--- a/anthropic-ai-sdk/src/types/admin/workspaces.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspaces.rs
@@ -86,6 +86,28 @@ pub struct ListWorkspacesResponse {
 /// Response type for retrieving a workspace.
 pub type GetWorkspaceResponse = Workspace;
 
+/// Response type for creating a workspace.
+pub type CreateWorkspaceResponse = Workspace;
+
+/// Parameters for creating a workspace.
+#[derive(Debug, Serialize)]
+pub struct AdminCreateWorkspaceParams {
+    /// Name of the Workspace (1-40 characters).
+    pub name: String,
+}
+
+impl AdminCreateWorkspaceParams {
+    /// Create a new `AdminCreateWorkspaceParams` with the required name.
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into();
+        assert!(
+            !name.is_empty() && name.chars().count() <= 40,
+            "workspace name must be 1-40 characters"
+        );
+        Self { name }
+    }
+}
+
 /// Parameters for updating a workspace.
 #[derive(Debug, Serialize)]
 pub struct AdminUpdateWorkspaceParams {
@@ -109,6 +131,7 @@ impl AdminUpdateWorkspaceParams {
 mod tests {
     use super::ListWorkspacesParams;
     use super::AdminUpdateWorkspaceParams;
+    use super::AdminCreateWorkspaceParams;
 
     #[test]
     fn limit_clamps_upper_bound() {
@@ -139,6 +162,25 @@ mod tests {
     fn update_params_rejects_long_name() {
         let s = "a".repeat(41);
         AdminUpdateWorkspaceParams::new(s);
+    }
+
+    #[test]
+    fn create_params_accepts_valid_name() {
+        let params = AdminCreateWorkspaceParams::new("valid");
+        assert_eq!(params.name, "valid");
+    }
+
+    #[test]
+    #[should_panic]
+    fn create_params_rejects_empty_name() {
+        AdminCreateWorkspaceParams::new("");
+    }
+
+    #[test]
+    #[should_panic]
+    fn create_params_rejects_long_name() {
+        let s = "a".repeat(41);
+        AdminCreateWorkspaceParams::new(s);
     }
 }
 

--- a/examples/admin/workspace-management/create-workspace/Cargo.toml
+++ b/examples/admin/workspace-management/create-workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "create-workspace"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = {path = "../../../../anthropic-ai-sdk"}
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-management/create-workspace/src/main.rs
+++ b/examples/admin/workspace-management/create-workspace/src/main.rs
@@ -1,0 +1,39 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use anthropic_ai_sdk::types::admin::workspaces::AdminCreateWorkspaceParams;
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_name = args.get(1).expect("Provide workspace name as argument");
+
+    let params = AdminCreateWorkspaceParams::new(workspace_name);
+
+    match AdminClient::create_workspace(&client, &params).await {
+        Ok(ws) => {
+            info!("Created workspace: {} ({})", ws.name, ws.id);
+        }
+        Err(e) => {
+            error!("Error creating workspace: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support Admin API workspace creation
- expose endpoint through the AdminClient trait and implementation
- provide parameters and response types for workspace creation
- add example for creating a workspace

## Testing
- `cargo fmt` *(fails: `cargo-fmt` not installed)*
- `cargo check --workspace` *(fails: could not connect to crates.io)*
- `cargo test --workspace` *(fails: could not connect to crates.io)*