### PR TITLE
Add delete workspace member endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "examples/admin/workspace-member-management/list-workspace-members",
     "examples/admin/workspace-member-management/add-workspace-member",
     "examples/admin/workspace-member-management/update-workspace-member",
+    "examples/admin/workspace-member-management/delete-workspace-member",
     "examples/admin/organization-invites/get-invite",
     "examples/admin/organization-invites/list-invites",
     "examples/admin/organization-invites/create-invite",

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -134,7 +134,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
     - [x] List Workspace Members
     - [x] Add Workspace Member
     - [x] Update Workspace Member
-    - [ ] Delete Workspace Member
+    - [x] Delete Workspace Member
   - API Keys
     - [x] Get API Key
     - [x] List API Keys

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -302,6 +302,18 @@ impl AdminClient for AnthropicClient {
         .await
     }
 
+    async fn delete_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        user_id: &'a str,
+    ) -> Result<crate::types::admin::workspace_members::DeleteWorkspaceMemberResponse, AdminError> {
+        self.delete::<crate::types::admin::workspace_members::DeleteWorkspaceMemberResponse, (), AdminError>(
+            &format!("/organizations/workspaces/{}/members/{}", workspace_id, user_id),
+            Option::<&()>::None,
+        )
+        .await
+    }
+
     async fn list_invites<'a>(
         &'a self,
         params: Option<&'a ListInvitesParams>,

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -106,6 +106,12 @@ pub trait AdminClient {
         params: &'a crate::types::admin::workspace_members::AdminUpdateWorkspaceMemberParams,
     ) -> Result<crate::types::admin::workspace_members::WorkspaceMember, AdminError>;
 
+    async fn delete_workspace_member<'a>(
+        &'a self,
+        workspace_id: &'a str,
+        user_id: &'a str,
+    ) -> Result<crate::types::admin::workspace_members::DeleteWorkspaceMemberResponse, AdminError>;
+
     async fn list_invites<'a>(
         &'a self,
         params: Option<&'a ListInvitesParams>,

--- a/anthropic-ai-sdk/src/types/admin/workspace_members.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspace_members.rs
@@ -112,6 +112,18 @@ pub struct ListWorkspaceMembersResponse {
 /// Response type for retrieving a workspace member.
 pub type GetWorkspaceMemberResponse = WorkspaceMember;
 
+/// Response type for deleting a workspace member.
+#[derive(Debug, Deserialize)]
+pub struct DeleteWorkspaceMemberResponse {
+    /// ID of the User.
+    pub user_id: String,
+    /// ID of the Workspace.
+    pub workspace_id: String,
+    /// Deleted object type. Always `"workspace_member_deleted"`.
+    #[serde(rename = "type")]
+    pub obj_type: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::ListWorkspaceMembersParams;

--- a/examples/admin/workspace-member-management/delete-workspace-member/Cargo.toml
+++ b/examples/admin/workspace-member-management/delete-workspace-member/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "delete-workspace-member"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing-subscriber = "0.3.19"
+tracing = "0.1.41"

--- a/examples/admin/workspace-member-management/delete-workspace-member/src/main.rs
+++ b/examples/admin/workspace-member-management/delete-workspace-member/src/main.rs
@@ -1,0 +1,37 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args.get(1).expect("Provide workspace ID as first argument");
+    let user_id = args.get(2).expect("Provide user ID as second argument");
+
+    match AdminClient::delete_workspace_member(&client, workspace_id, user_id).await {
+        Ok(resp) => {
+            info!("Deleted workspace member: {} - {}", resp.obj_type, resp.user_id);
+        }
+        Err(e) => {
+            error!("Error deleting workspace member: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support deleting workspace members in Admin API
- add example for deleting workspace members
- document endpoint coverage

## Testing
- `cargo fmt` *(fails: component not installed)*
- `cargo clippy` *(fails: component not installed)*
- `cargo check --workspace --locked --offline` *(fails: missing dependencies offline)*