### PR TITLE
Add archive workspace admin endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "examples/admin/workspace-management/list-workspaces",
     "examples/admin/workspace-management/create-workspace",
     "examples/admin/workspace-management/update-workspace",
+    "examples/admin/workspace-management/archive-workspace",
     "examples/admin/workspace-member-management/get-workspace-member",
     "examples/admin/workspace-member-management/list-workspace-members",
     "examples/admin/workspace-member-management/add-workspace-member",

--- a/anthropic-ai-sdk/README.md
+++ b/anthropic-ai-sdk/README.md
@@ -128,7 +128,7 @@ Check out the [examples](https://github.com/e-bebe/anthropic-sdk-rs/tree/main/ex
     - [x] List Workspaces
     - [x] Update Workspace
     - [x] Create Workspace
-    - [ ] Archive Workspace
+    - [x] Archive Workspace
   - Workspace Member Management
     - [x] Get Workspace Member
     - [x] List Workspace Members

--- a/anthropic-ai-sdk/src/admin_client.rs
+++ b/anthropic-ai-sdk/src/admin_client.rs
@@ -257,6 +257,17 @@ impl AdminClient for AnthropicClient {
         .await
     }
 
+    async fn archive_workspace<'a>(
+        &'a self,
+        workspace_id: &'a str,
+    ) -> Result<crate::types::admin::workspaces::ArchiveWorkspaceResponse, AdminError> {
+        self.post(
+            &format!("/organizations/workspaces/{}/archive", workspace_id),
+            Option::<&()>::None,
+        )
+        .await
+    }
+
     async fn list_workspace_members<'a>(
         &'a self,
         workspace_id: &'a str,

--- a/anthropic-ai-sdk/src/types/admin/api_keys.rs
+++ b/anthropic-ai-sdk/src/types/admin/api_keys.rs
@@ -86,6 +86,11 @@ pub trait AdminClient {
         params: &'a crate::types::admin::workspaces::AdminUpdateWorkspaceParams,
     ) -> Result<crate::types::admin::workspaces::Workspace, AdminError>;
 
+    async fn archive_workspace<'a>(
+        &'a self,
+        workspace_id: &'a str,
+    ) -> Result<crate::types::admin::workspaces::ArchiveWorkspaceResponse, AdminError>;
+
     async fn list_workspace_members<'a>(
         &'a self,
         workspace_id: &'a str,

--- a/anthropic-ai-sdk/src/types/admin/workspaces.rs
+++ b/anthropic-ai-sdk/src/types/admin/workspaces.rs
@@ -89,6 +89,9 @@ pub type GetWorkspaceResponse = Workspace;
 /// Response type for creating a workspace.
 pub type CreateWorkspaceResponse = Workspace;
 
+/// Response type for archiving a workspace.
+pub type ArchiveWorkspaceResponse = Workspace;
+
 /// Parameters for creating a workspace.
 #[derive(Debug, Serialize)]
 pub struct AdminCreateWorkspaceParams {

--- a/examples/admin/workspace-management/archive-workspace/Cargo.toml
+++ b/examples/admin/workspace-management/archive-workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "archive-workspace"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anthropic-ai-sdk = { path = "../../../../anthropic-ai-sdk" }
+tokio = { version = "1.43.0", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"

--- a/examples/admin/workspace-management/archive-workspace/src/main.rs
+++ b/examples/admin/workspace-management/archive-workspace/src/main.rs
@@ -1,0 +1,43 @@
+use anthropic_ai_sdk::client::AnthropicClient;
+use anthropic_ai_sdk::types::admin::api_keys::{AdminClient, AdminError};
+use std::env;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), AdminError> {
+    tracing_subscriber::fmt()
+        .with_ansi(true)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_line_number(true)
+        .with_file(false)
+        .with_level(true)
+        .try_init()
+        .expect("Failed to initialize logger");
+
+    let admin_api_key = env::var("ANTHROPIC_ADMIN_KEY").expect("ANTHROPIC_ADMIN_KEY is not set");
+    let api_version = env::var("ANTHROPIC_API_VERSION").unwrap_or("2023-06-01".to_string());
+
+    let client = AnthropicClient::new_admin::<AdminError>(admin_api_key, api_version)?;
+
+    let args: Vec<String> = env::args().collect();
+    let workspace_id = args
+        .get(1)
+        .expect("Please provide a workspace ID as argument");
+
+    match AdminClient::archive_workspace(&client, workspace_id).await {
+        Ok(ws) => {
+            info!("Successfully archived workspace!");
+            info!("  ID: {}", ws.id);
+            info!("  Name: {}", ws.name);
+            if let Some(archived_at) = ws.archived_at {
+                info!("  Archived At: {}", archived_at);
+            }
+        }
+        Err(e) => {
+            error!("Error archiving workspace: {}", e);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support archiving workspaces via Admin API
- document archive workspace support in README
- add example showing how to archive a workspace

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo test` *(fails to fetch crates due to network)*